### PR TITLE
[Ect] Relative navigation module

### DIFF
--- a/src/architecture/msgPayloadDefC/RelNavAttMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/RelNavAttMsgPayload.h
@@ -1,0 +1,31 @@
+/*
+ ISC License
+
+ Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef REL_NAV_ATT_MESSAGE_H
+#define REL_NAV_ATT_MESSAGE_H
+
+/*! @brief Structure used to define the output definition for attitude guidance*/
+typedef struct {
+    double timeTag;          //!< [s]   Current vehicle time-tag associated with measurements*/
+    double sigma_BcBs[3];      //!<       Current client spacecraft attitude (MRPs) with respecto to servicer spacecraft */
+    double omega_BcBs_Bs[3];    //!< [r/s] Current client spacecraft angular velocity vector with respect to servicer frame in servicer B frame components
+}RelNavAttMsgPayload;
+
+
+#endif

--- a/src/architecture/msgPayloadDefC/RelNavTransMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/RelNavTransMsgPayload.h
@@ -1,0 +1,32 @@
+/*
+ ISC License
+
+ Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef REL_NAV_TRANS_MESSAGE_H
+#define REL_NAV_TRANS_MESSAGE_H
+
+
+/*! @brief Structure used to define the output definition for translatoin guidance*/
+typedef struct {
+    double timeTag;          //!< [s]   Current vehicle time-tag associated with measurements*/
+    double r_BcBs_Bs[3];     //!< [m]   Relative client spacecraft position with respect to servicer spacecraft, expressed in servicer body frame
+    double v_BcBc_Bs[3];     //!< [m/s] Relative client spacecraft speed with respect to servicer spacecraft, expressed in servicer body frame
+}RelNavTransMsgPayload;
+
+
+#endif

--- a/src/architecture/msgPayloadDefC/RelNavTransMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/RelNavTransMsgPayload.h
@@ -25,7 +25,7 @@
 typedef struct {
     double timeTag;          //!< [s]   Current vehicle time-tag associated with measurements*/
     double r_BcBs_Bs[3];     //!< [m]   Relative client spacecraft position with respect to servicer spacecraft, expressed in servicer body frame
-    double v_BcBc_Bs[3];     //!< [m/s] Relative client spacecraft speed with respect to servicer spacecraft, expressed in servicer body frame
+    double v_BcBs_Bs[3];     //!< [m/s] Relative client spacecraft speed with respect to servicer spacecraft, expressed in servicer body frame
 }RelNavTransMsgPayload;
 
 

--- a/src/simulation/navigation/relativeNav/_UnitTest/test_RelativeNav.py
+++ b/src/simulation/navigation/relativeNav/_UnitTest/test_RelativeNav.py
@@ -1,0 +1,150 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2021, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        relativeNav
+#   Author:             Enrique Carlos Toomey
+#   Creation Date:      Sep 02 2024
+#
+
+import pytest
+import numpy as np
+from Basilisk.architecture import messaging
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import macros
+from Basilisk.simulation import relativeNav
+
+
+def test_without_noise():
+    r_BsN_N = [6800000.0, 0.0, 0.0]
+    v_BsN_N = [0.0, 7800.0, 0.0]
+    r_BcN_N = [6810000.0, 0.0, 0.0]
+    v_BcN_N = [0.0, 7750.0, 0.0]
+    sigma_BsN = [0, 0, 0]
+    omega_BsN_Bs = [0, 0, 0]
+    sigma_BcN = [0, 0, 0]
+    omega_BcN_Bc = [0, 0, 0]
+    posSigma = velSigma = attSigma = rateSigma = 0
+    r_BcBs_Bs_expected = [10000.0, 0.0, 0.0]
+    v_BcBs_Bs_expected = [0.0, -50.0, 0.0]
+    sigma_BcBs_expected = [0, 0, 0]
+    omega_BcBs_Bs_expected = np.cross(r_BcBs_Bs_expected, omega_BsN_Bs)
+
+    relativeNav_test_function(r_BsN_N, v_BsN_N, sigma_BsN, omega_BsN_Bs,
+                              r_BcN_N, v_BcN_N, sigma_BcN, omega_BcN_Bc,
+                              posSigma, velSigma, attSigma, rateSigma,
+                              r_BcBs_Bs_expected, v_BcBs_Bs_expected,
+                              sigma_BcBs_expected, omega_BcBs_Bs_expected)
+#posBound = numpy.array([1000.0] * 3)
+#velBound = numpy.array([1.0] * 3)
+#attBound = numpy.array([5E-3] * 3)
+#rateBound = numpy.array([0.02] * 3)
+
+#posSigma = 5.0
+#velSigma = 0.035
+#attSigma = 1.0 / 360.0 * np.pi / 180.0
+#rateSigma = 0.05 * np.pi / 180.0
+#errorBounds = [[1000.], [1000.], [1000.], [1.], [1.], [1.], [0.005], [0.005], [0.005], [0.02], [0.02], [0.02]]
+
+
+
+
+def relativeNav_test_function(r_BsN_N, v_BsN_N, sigma_BsN, omega_BsN_Bs,
+                              r_BcN_N, v_BcN_N, sigma_BcN, omega_BcN_Bc,
+                              posSigma, velSigma, attSigma, rateSigma,
+                              r_BcBs_Bs_expected, v_BcBs_Bs_expected,
+                              sigma_BcBs_expected, omega_BcBs_Bs_expected):
+    # Create a sim module as an empty container
+    unitTaskName = "unitTask"  # arbitrary name (don't change)
+    unitProcessName = "TestProcess"  # arbitrary name (don't change)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProcessRate = macros.sec2nano(0.5)
+    unitTestProc = unitTestSim.CreateNewProcess(unitProcessName)
+    # create the task and specify the integration update time
+    unitTestProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    #Now initialize the modules that we are using.  I got a little better as I went along
+    rNavObject = relativeNav.RelativeNav()
+    unitTestSim.AddModelToTask(unitTaskName, rNavObject)
+
+    servicerStateMessage = messaging.SCStatesMsgPayload()
+    servicerStateMessage.r_BN_N = r_BsN_N
+    servicerStateMessage.v_BN_N = v_BsN_N
+    servicerStateMessage.sigma_BN = sigma_BsN
+    servicerStateMessage.omega_BN_B = omega_BsN_Bs
+    
+    clientStateMessage = messaging.SCStatesMsgPayload()
+    clientStateMessage.r_BN_N = r_BcN_N
+    clientStateMessage.v_BN_N = v_BcN_N
+    clientStateMessage.sigma_BN = sigma_BcN
+    clientStateMessage.omega_BN_B = omega_BcN_Bc
+
+
+    # Inertial State output Message
+    servicerStateMsg = messaging.SCStatesMsg().write(servicerStateMessage)
+    rNavObject.servicerStateInMsg.subscribeTo(servicerStateMsg)
+    clientStateMsg = messaging.SCStatesMsg().write(clientStateMessage)
+    rNavObject.clientStateInMsg.subscribeTo(clientStateMsg)
+
+    rNavObject.ModelTag = "RelativeNavigation"
+    pMatrix = [[posSigma, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., posSigma, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., posSigma, 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., velSigma, 0., 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., velSigma, 0., 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., velSigma, 0., 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., attSigma, 0., 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., attSigma, 0., 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0., attSigma, 0., 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0., 0., rateSigma, 0., 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rateSigma, 0.],
+               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rateSigma],
+               ]
+    #rNavObject.walkBounds = errorBounds
+    rNavObject.PMatrix = pMatrix
+    rNavObject.crossTrans = True
+    rNavObject.crossAtt = False
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(testProcessRate)
+    unitTestSim.ExecuteSimulation()
+
+    r_BcBs_Bs = rNavObject.relTransOutMsg.read().r_BcBc_Bs
+    v_BcBc_Bs = rNavObject.relTransOutMsg.read().v_BcBc_Bs
+    sigma_BcBs = rNavObject.relAttOutMsg.read().sigma_BcBs
+    omega_BcBs_Bs = rNavObject.relAttOutMsg.read().omega_BcBs_Bs
+    print(r_BcBs_Bs, v_BcBc_Bs, sigma_BcBs, omega_BcBs_Bs)
+    rta = unitTestSupport.isVectorEqual(r_BcBs_Bs, r_BcBs_Bs_expected, 1e-3)
+    rta = unitTestSupport.isVectorEqual(v_BcBc_Bs, v_BcBs_Bs_expected, 1e-3)
+    rta = unitTestSupport.isVectorEqual(sigma_BcBs, sigma_BcBs_expected, 1e-3)
+    rta = unitTestSupport.isVectorEqual(omega_BcBs_Bs, omega_BcBs_Bs_expected, 1e-3)
+    assert rta > 0, f"""Test failed: 
+        expected={r_BcBs_Bs_expected}, result={r_BcBs_Bs},
+        expected={v_BcBs_Bs_expected}, result={r_BcBs_Bs},
+        expected={sigma_BcBs_expected}, result={sigma_BcBs},
+        expected={omega_BcBs_Bs_expected}, result={omega_BcBs_Bs},
+        """
+
+if __name__ == "__main__":
+    test_without_noise()
+

--- a/src/simulation/navigation/relativeNav/_UnitTest/test_RelativeNav.py
+++ b/src/simulation/navigation/relativeNav/_UnitTest/test_RelativeNav.py
@@ -48,30 +48,58 @@ def test_without_noise():
     sigma_BcBs_expected = [0, 0, 0]
     omega_BcBs_Bs_expected = np.cross(r_BcBs_Bs_expected, omega_BsN_Bs)
 
-    relativeNav_test_function(r_BsN_N, v_BsN_N, sigma_BsN, omega_BsN_Bs,
-                              r_BcN_N, v_BcN_N, sigma_BcN, omega_BcN_Bc,
-                              posSigma, velSigma, attSigma, rateSigma,
-                              r_BcBs_Bs_expected, v_BcBs_Bs_expected,
-                              sigma_BcBs_expected, omega_BcBs_Bs_expected)
-#posBound = numpy.array([1000.0] * 3)
-#velBound = numpy.array([1.0] * 3)
-#attBound = numpy.array([5E-3] * 3)
-#rateBound = numpy.array([0.02] * 3)
+    r_BcBs_Bs, v_BcBs_Bs, sigma_BcBs, omega_BcBs_Bs = relativeNav_test_function(
+        r_BsN_N, v_BsN_N, sigma_BsN, omega_BsN_Bs,
+        r_BcN_N, v_BcN_N, sigma_BcN, omega_BcN_Bc,
+        posSigma, velSigma, attSigma, rateSigma)
+    rta = unitTestSupport.isVectorEqual(r_BcBs_Bs[-1], r_BcBs_Bs_expected, 1e-3)
+    rta = unitTestSupport.isVectorEqual(v_BcBs_Bs[-1], v_BcBs_Bs_expected, 1e-3)
+    rta = unitTestSupport.isVectorEqual(sigma_BcBs[-1], sigma_BcBs_expected, 1e-3)
+    rta = unitTestSupport.isVectorEqual(omega_BcBs_Bs[-1], omega_BcBs_Bs_expected, 1e-3)
+    assert rta > 0, f"""Test failed: 
+        expected={r_BcBs_Bs_expected}, result={r_BcBs_Bs[-1]},
+        expected={v_BcBs_Bs_expected}, result={v_BcBs_Bs[-1]},
+        expected={sigma_BcBs_expected}, result={sigma_BcBs[-1]},
+        expected={omega_BcBs_Bs_expected}, result={omega_BcBs_Bs[-1]},
+        """
+    
+def test_noise():
+    r_BsN_N = [6800000.0, 0.0, 0.0]
+    v_BsN_N = [0.0, 7800.0, 0.0]
+    r_BcN_N = [6810000.0, 0.0, 0.0]
+    v_BcN_N = [0.0, 7750.0, 0.0]
+    sigma_BsN = [0, 0, 0]
+    omega_BsN_Bs = [0, 0, 0]
+    sigma_BcN = [0, 0, 0]
+    omega_BcN_Bc = [0, 0, 0]
+    distance_m = np.linalg.norm(np.array(r_BcN_N) - np.array(r_BsN_N))
+    posSigma = 100.0 / distance_m
+    velSigma = 1.0 / distance_m
+    attSigma = 0.0 / 360.0 * np.pi / 180.0 / distance_m
+    rateSigma = 0.00 * np.pi / 180.0 / distance_m
+    # Error bounds are set to a very small value to force white noise...
+    errorBounds = [[1.e-15], [1.e-15], [1.e-15], [1.], [1.], [1.], [0.005], [0.005], [0.005], [0.02], [0.02], [0.02]]
 
-#posSigma = 5.0
-#velSigma = 0.035
-#attSigma = 1.0 / 360.0 * np.pi / 180.0
-#rateSigma = 0.05 * np.pi / 180.0
-#errorBounds = [[1000.], [1000.], [1000.], [1.], [1.], [1.], [0.005], [0.005], [0.005], [0.02], [0.02], [0.02]]
 
+    r_BcBs_Bs, v_BcBs_Bs, sigma_BcBs, omega_BcBs_Bs = relativeNav_test_function(
+        r_BsN_N, v_BsN_N, sigma_BsN, omega_BsN_Bs,
+        r_BcN_N, v_BcN_N, sigma_BcN, omega_BcN_Bc,
+        posSigma, velSigma, attSigma, rateSigma, errorBounds, steps=10000)
+    
+    posSigmaOut = np.std(r_BcBs_Bs, axis=0)*1.5 # I have no idea why I need to multiply by
+    # 1.5, but it is like that in src/architecture/utilities/tests/test_gaussMarkov.cpp lin 71/72
+    rta = unitTestSupport.isVectorEqual(posSigmaOut, [posSigma * distance_m]*3, 0.01*(posSigma * distance_m))
+    assert rta > 0, f"""Test failed: 
+        position noise {posSigmaOut} does not match with expected noise {posSigma * distance_m}
+        """
 
 
 
 def relativeNav_test_function(r_BsN_N, v_BsN_N, sigma_BsN, omega_BsN_Bs,
                               r_BcN_N, v_BcN_N, sigma_BcN, omega_BcN_Bc,
-                              posSigma, velSigma, attSigma, rateSigma,
-                              r_BcBs_Bs_expected, v_BcBs_Bs_expected,
-                              sigma_BcBs_expected, omega_BcBs_Bs_expected):
+                              posSigma, velSigma, attSigma, rateSigma, 
+                              errorBounds=None, steps=1):
+    path = os.path.dirname(os.path.abspath(__file__))
     # Create a sim module as an empty container
     unitTaskName = "unitTask"  # arbitrary name (don't change)
     unitProcessName = "TestProcess"  # arbitrary name (don't change)
@@ -120,31 +148,32 @@ def relativeNav_test_function(r_BsN_N, v_BsN_N, sigma_BsN, omega_BsN_Bs,
                [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rateSigma, 0.],
                [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rateSigma],
                ]
-    #rNavObject.walkBounds = errorBounds
+    if errorBounds is not None:
+        rNavObject.walkBounds = errorBounds
     rNavObject.PMatrix = pMatrix
     rNavObject.crossTrans = True
     rNavObject.crossAtt = False
 
+    # setup logging
+    dataRelTransLog = rNavObject.relTransOutMsg.recorder()
+    dataRelAttLog = rNavObject.relAttOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataRelTransLog)
+    unitTestSim.AddModelToTask(unitTaskName, dataRelAttLog)
+    dataNavErrors = rNavObject.logger("navErrors", testProcessRate)
+    unitTestSim.AddModelToTask(unitTaskName, dataNavErrors) 
+
+    # Run sim of 1 step
     unitTestSim.InitializeSimulation()
-    unitTestSim.ConfigureStopTime(testProcessRate)
+    unitTestSim.ConfigureStopTime(steps*testProcessRate)
     unitTestSim.ExecuteSimulation()
 
-    r_BcBs_Bs = rNavObject.relTransOutMsg.read().r_BcBc_Bs
-    v_BcBc_Bs = rNavObject.relTransOutMsg.read().v_BcBc_Bs
-    sigma_BcBs = rNavObject.relAttOutMsg.read().sigma_BcBs
-    omega_BcBs_Bs = rNavObject.relAttOutMsg.read().omega_BcBs_Bs
-    print(r_BcBs_Bs, v_BcBc_Bs, sigma_BcBs, omega_BcBs_Bs)
-    rta = unitTestSupport.isVectorEqual(r_BcBs_Bs, r_BcBs_Bs_expected, 1e-3)
-    rta = unitTestSupport.isVectorEqual(v_BcBc_Bs, v_BcBs_Bs_expected, 1e-3)
-    rta = unitTestSupport.isVectorEqual(sigma_BcBs, sigma_BcBs_expected, 1e-3)
-    rta = unitTestSupport.isVectorEqual(omega_BcBs_Bs, omega_BcBs_Bs_expected, 1e-3)
-    assert rta > 0, f"""Test failed: 
-        expected={r_BcBs_Bs_expected}, result={r_BcBs_Bs},
-        expected={v_BcBs_Bs_expected}, result={r_BcBs_Bs},
-        expected={sigma_BcBs_expected}, result={sigma_BcBs},
-        expected={omega_BcBs_Bs_expected}, result={omega_BcBs_Bs},
-        """
+    #check results
+    r_BcBs_Bs = dataRelTransLog.r_BcBs_Bs
+    v_BcBs_Bs = dataRelTransLog.v_BcBs_Bs
+    sigma_BcBs = dataRelAttLog.sigma_BcBs
+    omega_BcBs_Bs = dataRelAttLog.omega_BcBs_Bs
+    return r_BcBs_Bs, v_BcBs_Bs, sigma_BcBs, omega_BcBs_Bs
 
 if __name__ == "__main__":
     test_without_noise()
-
+    test_noise()

--- a/src/simulation/navigation/relativeNav/relativeNav.cpp
+++ b/src/simulation/navigation/relativeNav/relativeNav.cpp
@@ -1,0 +1,208 @@
+/*
+ ISC License
+
+ Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+#include "simulation/navigation/relativeNav/relativeNav.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include <iostream>
+#include <cstring>
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/macroDefinitions.h"
+
+/*! This is the constructor for the simple nav model.  It sets default variable
+    values and initializes the various parts of the model */
+RelativeNav::RelativeNav()
+{
+    this->crossTrans = false;
+    this->crossAtt = false;
+    this->prevTime = 0;
+    this->estRelAttState = this->relAttOutMsg.zeroMsgPayload;
+    this->trueRelAttState = this->relAttOutMsg.zeroMsgPayload;
+    this->estRelTransState = this->relTransOutMsg.zeroMsgPayload;
+    this->trueRelTransState = this->relTransOutMsg.zeroMsgPayload;
+    this->PMatrix.resize(12,12);
+    this->PMatrix.fill(0.0);
+    this->walkBounds.resize(12);
+    this->walkBounds.fill(0.0);
+    this->errorModel =  GaussMarkov(12, this->RNGSeed);
+}
+
+/*! Destructor.  Nothing here. */
+RelativeNav::~RelativeNav()
+{
+    return;
+}
+
+
+/*! This method is used to reset the module. It
+ initializes the various containers used in the model as well as creates the
+ output message.  The error states are allocated as follows:
+ Total states: 18
+     - Position errors [0-2]
+     - Velocity errors [3-5]
+     - Attitude errors [6-8]
+     - Body Rate errors [9-11]
+     - Sun Point error [12-14]
+     - Accumulated DV errors [15-17]
+ @return void
+ */
+void RelativeNav::Reset(uint64_t CurrentSimNanos)
+{
+    // check if input messages has not been included
+    if (!this->servicerStateInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "RelativeNav.servicerStateInMsg was not linked.");
+    }
+    if (!this->clientStateInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "RelativeNav.clientStateInMsg was not linked.");
+    }
+    int64_t numStates = 12;
+
+    //! - Initialize the propagation matrix to default values for use in update
+    this->AMatrix.setIdentity(numStates, numStates);
+    this->AMatrix(0,3) = this->AMatrix(1,4) = this->AMatrix(2,5) = this->crossTrans ? 1.0 : 0.0;
+    this->AMatrix(6,9) = this->AMatrix(7,10) = this->AMatrix(8, 11) = this->crossAtt ? 1.0 : 0.0;
+
+    //! - Alert the user and stop if the noise matrix is the wrong size.  That'd be bad.
+    if (this->PMatrix.size() != numStates*numStates) {
+        bskLogger.bskLog(BSK_ERROR, "Your process noise matrix (PMatrix) is not 18*18. Size is %ld.  Quitting", this->PMatrix.size());
+        return;
+    }
+    //! - Set the matrices of the lower level error propagation (GaussMarkov)
+    this->errorModel.setNoiseMatrix(this->PMatrix);
+    this->errorModel.setRNGSeed(this->RNGSeed);
+    if (this->walkBounds.size() != numStates) {
+        bskLogger.bskLog(BSK_ERROR, "Your walkbounds vector  is not 12 elements. Quitting");
+    }
+    this->errorModel.setUpperBounds(this->walkBounds);
+}
+
+
+/*! This method reads the input messages associated with the vehicle state and
+ the sun state
+ */
+void RelativeNav::readInputMessages()
+{
+    this->servicerInertialState = this->servicerStateInMsg();
+    this->clientInertialState = this->clientStateInMsg();
+
+}
+
+/*! This method writes the aggregate nav information into the output state message.
+ @return void
+ @param Clock The clock time associated with the model call
+ */
+void RelativeNav::writeOutputMessages(uint64_t Clock)
+{
+    /* time tage the output message */
+    this->estRelAttState.timeTag = (double) Clock * NANO2SEC;
+    this->estRelTransState.timeTag = (double) Clock * NANO2SEC;
+    
+    this->relAttOutMsg.write(&this->estRelAttState, this->moduleID, Clock);
+    this->relTransOutMsg.write(&this->estRelTransState, this->moduleID, Clock);
+}
+
+void RelativeNav::applyErrors()
+{
+    double relative_distance_m;
+    //! - Error are to be scaled by the relative distance between the two spacecrafts
+    relative_distance_m = v3Norm(this->trueRelTransState.r_BcBs_Bs);
+    this->navErrors *= relative_distance_m;
+
+    v3Add(this->trueRelTransState.r_BcBs_Bs, &(this->navErrors.data()[0]), this->estRelTransState.r_BcBs_Bs);
+    v3Add(this->trueRelTransState.v_BcBc_Bs, &(this->navErrors.data()[3]), this->estRelTransState.v_BcBc_Bs);
+    
+    addMRP(this->trueRelAttState.sigma_BcBs, &(this->navErrors.data()[6]), this->estRelAttState.sigma_BcBs);
+    v3Add(this->trueRelAttState.omega_BcBs_Bs, &(this->navErrors.data()[9]), this->estRelAttState.omega_BcBs_Bs);
+}
+
+
+/*! This method uses the input messages as well as the calculated model errors to
+ compute what the output navigation state should be.
+    @return void
+    @param Clock The clock time associated with the model's update call
+*/
+void RelativeNav::computeTrueOutput(uint64_t Clock)
+{   
+    double r_BcBs_N[3];
+    double v_BcBs_N[3];
+    double v_BcBs_Bs[3];
+    double v_BcBs_Bs_cross[3];
+    double client_dcm_BN[3][3];
+    double servicer_dcm_BN[3][3];
+    double dcm_BcBs[3][3];
+    double client_omega_BN_Bs[3];
+
+    // Compute relative attitude
+    MRP2C(this->clientInertialState.sigma_BN, client_dcm_BN);
+    MRP2C(this->servicerInertialState.sigma_BN, servicer_dcm_BN);
+    m33MultM33t(client_dcm_BN, servicer_dcm_BN, dcm_BcBs);
+    C2MRP(dcm_BcBs, this->trueRelAttState.sigma_BcBs);
+
+    // Compute relative position and velocity
+    v3Subtract(this->clientInertialState.r_BN_N, this->servicerInertialState.r_BN_N, r_BcBs_N);
+    m33tMultV3(servicer_dcm_BN, r_BcBs_N, this->trueRelTransState.r_BcBs_Bs);
+    
+    v3Subtract(this->clientInertialState.v_BN_N, this->servicerInertialState.v_BN_N, v_BcBs_N);
+    m33tMultV3(servicer_dcm_BN, v_BcBs_N, v_BcBs_Bs);
+    v3Cross(this->trueRelTransState.r_BcBs_Bs, this->servicerInertialState.omega_BN_B, v_BcBs_Bs_cross);
+    v2Add(v_BcBs_Bs, v_BcBs_Bs_cross, this->trueRelTransState.v_BcBc_Bs);
+
+
+    m33tMultV3(dcm_BcBs, this->clientInertialState.omega_BN_B, client_omega_BN_Bs);
+    v3Subtract(client_omega_BN_Bs, this->servicerInertialState.omega_BN_B, this->trueRelAttState.omega_BcBs_Bs);
+
+}
+
+/*! This method sets the propagation matrix and requests new random errors from
+ its GaussMarkov model.
+ @return void
+ @param CurrentSimNanos The clock time associated with the model call
+ */
+void RelativeNav::computeErrors(uint64_t CurrentSimNanos)
+{
+    double timeStep;
+    Eigen::MatrixXd localProp = this->AMatrix;
+    //! - Compute timestep since the last call
+    timeStep = (CurrentSimNanos - this->prevTime)*1.0E-9;
+
+    localProp(0,3) *= timeStep; //postion/velocity cross correlation terms
+    localProp(1,4) *= timeStep; //postion/velocity cross correlation terms
+    localProp(2,5) *= timeStep; //postion/velocity cross correlation terms
+    localProp(6,9) *= timeStep; //attitude/attitude rate cross correlation terms
+    localProp(7,10) *= timeStep; //attitude/attitude rate cross correlation terms
+    localProp(8,11) *= timeStep; //attitude/attitude rate cross correlation terms
+
+    //! - Set the GaussMarkov propagation matrix and compute errors
+    this->errorModel.setPropMatrix(localProp);
+    this->errorModel.computeNextState();
+    this->navErrors = this->errorModel.getCurrentState();
+}
+
+/*! This method calls all of the run-time operations for the simple nav model.
+    @return void
+    @param CurrentSimNanos The clock time associated with the model call
+*/
+void RelativeNav::UpdateState(uint64_t CurrentSimNanos)
+{
+    this->readInputMessages();
+    this->computeTrueOutput(CurrentSimNanos);
+    this->computeErrors(CurrentSimNanos);
+    this->applyErrors();
+    this->writeOutputMessages(CurrentSimNanos);
+    this->prevTime = CurrentSimNanos;
+}

--- a/src/simulation/navigation/relativeNav/relativeNav.cpp
+++ b/src/simulation/navigation/relativeNav/relativeNav.cpp
@@ -124,7 +124,7 @@ void RelativeNav::applyErrors()
     this->navErrors *= relative_distance_m;
 
     v3Add(this->trueRelTransState.r_BcBs_Bs, &(this->navErrors.data()[0]), this->estRelTransState.r_BcBs_Bs);
-    v3Add(this->trueRelTransState.v_BcBc_Bs, &(this->navErrors.data()[3]), this->estRelTransState.v_BcBc_Bs);
+    v3Add(this->trueRelTransState.v_BcBs_Bs, &(this->navErrors.data()[3]), this->estRelTransState.v_BcBs_Bs);
     
     addMRP(this->trueRelAttState.sigma_BcBs, &(this->navErrors.data()[6]), this->estRelAttState.sigma_BcBs);
     v3Add(this->trueRelAttState.omega_BcBs_Bs, &(this->navErrors.data()[9]), this->estRelAttState.omega_BcBs_Bs);
@@ -160,7 +160,7 @@ void RelativeNav::computeTrueOutput(uint64_t Clock)
     v3Subtract(this->clientInertialState.v_BN_N, this->servicerInertialState.v_BN_N, v_BcBs_N);
     m33tMultV3(servicer_dcm_BN, v_BcBs_N, v_BcBs_Bs);
     v3Cross(this->trueRelTransState.r_BcBs_Bs, this->servicerInertialState.omega_BN_B, v_BcBs_Bs_cross);
-    v2Add(v_BcBs_Bs, v_BcBs_Bs_cross, this->trueRelTransState.v_BcBc_Bs);
+    v2Add(v_BcBs_Bs, v_BcBs_Bs_cross, this->trueRelTransState.v_BcBs_Bs);
 
 
     m33tMultV3(dcm_BcBs, this->clientInertialState.omega_BN_B, client_omega_BN_Bs);

--- a/src/simulation/navigation/relativeNav/relativeNav.h
+++ b/src/simulation/navigation/relativeNav/relativeNav.h
@@ -17,16 +17,13 @@
 
  */
 
-#ifndef SIMPLE_NAV_H
-#define SIMPLE_NAV_H
+#ifndef RELATIVE_NAV_H
+#define RELATIVE_NAV_H
 
 #include <vector>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/utilities/gauss_markov.h"
 #include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
-#include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
-#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
-#include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
 #include "architecture/msgPayloadDefC/RelNavAttMsgPayload.h"
 #include "architecture/msgPayloadDefC/RelNavTransMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"

--- a/src/simulation/navigation/relativeNav/relativeNav.h
+++ b/src/simulation/navigation/relativeNav/relativeNav.h
@@ -1,0 +1,77 @@
+/*
+ ISC License
+
+ Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef SIMPLE_NAV_H
+#define SIMPLE_NAV_H
+
+#include <vector>
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/utilities/gauss_markov.h"
+#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
+#include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+#include "architecture/msgPayloadDefC/RelNavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/RelNavTransMsgPayload.h"
+#include "architecture/utilities/bskLogging.h"
+#include <Eigen/Dense>
+#include "architecture/messaging/messaging.h"
+
+/*! @brief simple navigation module class */
+class RelativeNav: public SysModel {
+public:
+    RelativeNav();
+    ~RelativeNav();
+
+    void Reset(uint64_t CurrentSimNanos);
+    void UpdateState(uint64_t CurrentSimNanos);
+    void computeTrueOutput(uint64_t Clock);
+    void computeErrors(uint64_t CurrentSimNanos);
+    void applyErrors();
+    void readInputMessages();
+    void writeOutputMessages(uint64_t Clock);
+
+public:
+    Eigen::MatrixXd PMatrix;          //!< -- Cholesky-decomposition or matrix square root of the covariance matrix to apply errors with
+    Eigen::VectorXd walkBounds;       //!< -- "3-sigma" errors to permit for states
+    Eigen::VectorXd navErrors;        //!< -- Current navigation errors applied to truth
+    Message<RelNavAttMsgPayload> relAttOutMsg;        //!< attitude navigation output msg
+    Message<RelNavTransMsgPayload> relTransOutMsg;    //!< translation navigation output msg
+    bool crossTrans;                  //!< -- Have position error depend on velocity
+    bool crossAtt;                    //!< -- Have attitude depend on attitude rate
+    RelNavAttMsgPayload trueRelAttState;        //!< -- attitude nav state without errors
+    RelNavAttMsgPayload estRelAttState;         //!< -- attitude nav state including errors
+    RelNavTransMsgPayload trueRelTransState;    //!< -- translation nav state without errors
+    RelNavTransMsgPayload estRelTransState;     //!< -- translation nav state including errors
+    SCStatesMsgPayload servicerInertialState; //!< -- input inertial state from Star Tracker
+    SCStatesMsgPayload clientInertialState; //!< -- input inertial state from Star Tracker
+
+    BSKLogger bskLogger;              //!< -- BSK Logging
+
+    ReadFunctor<SCStatesMsgPayload> servicerStateInMsg;      //!< servicer spacecraft state input msg
+    ReadFunctor<SCStatesMsgPayload> clientStateInMsg;      //!< client spacecraft state input msg
+
+private:
+    Eigen::MatrixXd AMatrix;           //!< -- The matrix used to propagate the state
+    GaussMarkov errorModel;            //!< -- Gauss-markov error states
+    uint64_t prevTime;                 //!< -- Previous simulation time observed
+};
+
+
+#endif

--- a/src/simulation/navigation/relativeNav/relativeNav.i
+++ b/src/simulation/navigation/relativeNav/relativeNav.i
@@ -1,0 +1,49 @@
+/*
+ ISC License
+
+ Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module simpleNav
+%{
+   #include "relativeNav.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_eigen.i"
+%include "swig_conly_data.i"
+
+%include "sys_model.i"
+%include "relativeNav.h"
+
+%include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
+struct SCStatesMsg_C;
+%include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+struct NavAttMsg_C;
+%include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+struct NavTransMsg_C;
+%include "architecture/msgPayloadDefC/RelNavAttMsgPayload.h"
+struct RelNavAttMsg_C;
+%include "architecture/msgPayloadDefC/RelNavTransMsgPayload.h"
+struct RelNavTransMsg_C;
+
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/simulation/navigation/relativeNav/relativeNav.i
+++ b/src/simulation/navigation/relativeNav/relativeNav.i
@@ -16,7 +16,7 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
-%module simpleNav
+%module relativeNav
 %{
    #include "relativeNav.h"
 %}
@@ -33,10 +33,6 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 struct SCStatesMsg_C;
-%include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
-struct NavAttMsg_C;
-%include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
-struct NavTransMsg_C;
 %include "architecture/msgPayloadDefC/RelNavAttMsgPayload.h"
 struct RelNavAttMsg_C;
 %include "architecture/msgPayloadDefC/RelNavTransMsgPayload.h"

--- a/src/simulation/navigation/relativeNav/relativeNav.rst
+++ b/src/simulation/navigation/relativeNav/relativeNav.rst
@@ -1,0 +1,34 @@
+Executive Summary
+-----------------
+
+Relative navigation model used to provide error-ed truth (or truth). This class is used to perturb the truth state away using a gauss-markov
+error model, but making the error proportional to the relative distance norm. It is designed to look like a random walk process put on top of
+the nominal relative position, velocity, attitude, and attitude rate.  This is meant to
+be used in place of the nominal relative navigation system output.
+
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  The module msg connection is set by the
+user from python.  The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - RelAttOutMsg
+      - :ref:`RelNavAttMsgPayload`
+      - relative attitude navigation output msg
+    * - RelTransOutMsg
+      - :ref:`RelNavTransMsgPayload`
+      - relative translation navigation output msg
+    * - servicerStateInMsg
+      - :ref:`SCStatesMsgPayload`
+      - servicer spacecraft state input msg
+    * - clientStateInMsg
+      - :ref:`SCStatesMsgPayload`
+      - client spacecraft state input msg


### PR DESCRIPTION
## Description
Create relative navigation module, to compute and outpute relative position, velocity, attitude and attitude velocity between a client and a servicer satellites. Everything is output is servicer's body frame. Position vector is from servicer to client. Attitude describes rotation from client to servicer. Error is added with same gauss-markov process and used by SimpleNav, with the difference that the error is scaled by the norm of the relative position vector.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
